### PR TITLE
Allow override of device asserts, including multi-device support.

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -4419,6 +4419,9 @@ endif
 ifdef DEVICE_MANIFEST_FILE
 	$(hide) echo "vintf_include_empty_vendor_sku=true" >> $@
 endif
+ifneq ($(TARGET_OTA_ASSERT_DEVICE),)
+	$(hide) echo "ota_override_device=$(TARGET_OTA_ASSERT_DEVICE)" >> $@
+endif
 
 .PHONY: misc_info
 misc_info: $(INSTALLED_MISC_INFO_TARGET)

--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -390,7 +390,9 @@ class BuildInfo(object):
           "system_other"] = self._partition_fingerprints["system"]
 
     # These two should be computed only after setting self._oem_props.
-    self._device = self.GetOemProperty("ro.product.device")
+    self._device = info_dict.get("ota_override_device")
+    if not self._device:
+      self._device = self.GetOemProperty("ro.product.device")
     self._fingerprint = self.CalculateFingerprint()
     check_fingerprint(self._fingerprint)
 

--- a/tools/releasetools/edify_generator.py
+++ b/tools/releasetools/edify_generator.py
@@ -137,11 +137,13 @@ class EdifyGenerator(object):
 
   def AssertDevice(self, device):
     """Assert that the device identifier is the given string."""
-    cmd = ('getprop("ro.product.device") == "%s" || '
-           'abort("E%d: This package is for \\"%s\\" devices; '
-           'this is a \\"" + getprop("ro.product.device") + "\\".");') % (
-               device, common.ErrorCode.DEVICE_MISMATCH, device)
-    self.script.append(cmd)
+    cmd = ('assert(' +
+           ' || \0'.join(['getprop("ro.product.device") == "%s" || getprop("ro.build.product") == "%s"'
+                         % (i, i) for i in device.split(",")]) +
+           ' || abort("E%d: This package is for device: %s; ' +
+           'this device is " + getprop("ro.product.device") + ".");' +
+           ');') % (common.ErrorCode.DEVICE_MISMATCH, device)
+    self.script.append(self.WordWrap(cmd))
 
   def AssertSomeBootloader(self, *bootloaders):
     """Asert that the bootloader version is one of *bootloaders."""


### PR DESCRIPTION
Set in board file with TARGET_OTA_ASSERT_DEVICE.
(cherry-picked from commit 0f452f21fc9323b9d1fe746161761cf40aaa5030)

Change-Id: I3d06bdc0e3e26bde0c0e646accd050364f9713b9

ota_from_target_files: Remove device dependent arguments

These device-specific arguments are defined at build time and are
necessary to generate the zip correctly. Don't use command line
arguments to specify them, but write all the needed information
in misc_info.txt when the target-files zip is generated.
ota_from_target_files will then read misc_info.txt and set
everything automatically.

Change-Id: Ibdbca575b76eb07b53fccfcea52a351c7e333f91
Signed-off-by: André Pinela <sheffzor@gmail.com>