### PR TITLE
releasetools: ota_from_target_files: fix build for A-Only dynamic dev…

### DIFF
--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -868,7 +868,7 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
         info_dict=OPTIONS.info_dict,
         block_diffs=block_diff_dict.values(),
         progress_dict=progress_dict,
-        build_without_vendor=(not HasVendorPartition(input_zip)))
+        build_without_vendor=(not HasPartition(input_zip, "vendor")))
     dynamic_partitions_diff.WriteScript(script, output_zip,
                                         write_verify_script=OPTIONS.verify)
   else:


### PR DESCRIPTION
…ices not building vendor

The function `HasVendorParition()` was moved inside `HasTrebleEnabled()` in 9276cf0226d341927d0a7e682a8db677e25ae5dd
It also has a different implementation now

`HasPartition()` which was used by it earlier is still present, using the same implementation, so use that directly

Fixes the following error

Traceback (most recent call last):
  File "/home/akhil/eleven/out/host/linux-x86/bin/ota_from_target_files/internal/stdlib/runpy.py", line 174, in _run_module_as_main
  File "/home/akhil/eleven/out/host/linux-x86/bin/ota_from_target_files/internal/stdlib/runpy.py", line 72, in _run_code
  File "/home/akhil/eleven/out/host/linux-x86/bin/ota_from_target_files/__main__.py", line 12, in <module>
  File "/home/akhil/eleven/out/host/linux-x86/bin/ota_from_target_files/internal/stdlib/runpy.py", line 174, in _run_module_as_main
  File "/home/akhil/eleven/out/host/linux-x86/bin/ota_from_target_files/internal/stdlib/runpy.py", line 72, in _run_code
  File "/home/akhil/eleven/out/host/linux-x86/bin/ota_from_target_files/ota_from_target_files.py", line 2300, in <module>
  File "/home/akhil/eleven/out/host/linux-x86/bin/ota_from_target_files/ota_from_target_files.py", line 2279, in main
  File "/home/akhil/eleven/out/host/linux-x86/bin/ota_from_target_files/ota_from_target_files.py", line 2019, in GenerateNonAbOtaPackage
  File "/home/akhil/eleven/out/host/linux-x86/bin/ota_from_target_files/ota_from_target_files.py", line 855, in WriteFullOTAPackage
NameError: global name 'HasVendorPartition' is not defined

Change-Id: I9bd4ebc9d6b103cfd572bfd5eacd3f7a5b1a661c
Signed-off-by: Akhil Narang <me@akhilnarang.dev>