### PR TITLE
build: Support using a prebuilt recovery ramdisk

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -2175,9 +2175,18 @@ ifdef GENERIC_KERNEL_CMDLINE
   INTERNAL_RECOVERYIMAGE_ARGS += --cmdline "$(GENERIC_KERNEL_CMDLINE)"
 endif
 else # not (BUILDING_VENDOR_BOOT_IMAGE and AB_OTA_UPDATER)
+ifneq ($(TARGET_PREBUILT_RECOVERY_RAMDISK_IMG),)
   INTERNAL_RECOVERYIMAGE_ARGS := \
       $(addprefix --second ,$(INSTALLED_2NDBOOTLOADER_TARGET)) \
+      --kernel $(recovery_kernel) \
+      --ramdisk $(TARGET_PREBUILT_RECOVERY_RAMDISK_IMG)
+else
+  INTERNAL_RECOVERYIMAGE_ARGS := \
+      $(addprefix --second ,$(INSTALLED_2NDBOOTLOADER_TARGET)) \
+      --kernel $(recovery_kernel) \
       --ramdisk $(recovery_ramdisk)
+endif
+
 # Assumes this has already been stripped
 ifdef INTERNAL_KERNEL_CMDLINE
   INTERNAL_RECOVERYIMAGE_ARGS += --cmdline "$(INTERNAL_KERNEL_CMDLINE)"
@@ -4668,9 +4677,18 @@ $(BUILT_TARGET_FILES_PACKAGE): \
 	$(hide) mkdir -p $(dir $@) $(zip_root)
 ifneq (,$(INSTALLED_RECOVERYIMAGE_TARGET)$(filter true,$(BOARD_USES_RECOVERY_AS_BOOT)))
 	@# Components of the recovery image
+ifneq ($(TARGET_PREBUILT_RECOVERY_RAMDISK),)
+	$(hide) mkdir -p $(zip_root)/$(PRIVATE_RECOVERY_OUT)
+	$(hide) rm -rf $(PRODUCT_OUT)/prebuilt_recovery
+	$(hide) mkdir -p $(PRODUCT_OUT)/prebuilt_recovery
+	$(hide) unzip -o $(TARGET_PREBUILT_RECOVERY_RAMDISK) -d $(PRODUCT_OUT)/prebuilt_recovery/
+	$(hide) $(call package_files-copy-root, \
+	    $(PRODUCT_OUT)/prebuilt_recovery,$(zip_root)/$(PRIVATE_RECOVERY_OUT)/RAMDISK)
+else
 	$(hide) mkdir -p $(zip_root)/$(PRIVATE_RECOVERY_OUT)
 	$(hide) $(call package_files-copy-root, \
 	    $(TARGET_RECOVERY_ROOT_OUT),$(zip_root)/$(PRIVATE_RECOVERY_OUT)/RAMDISK)
+endif
 	@# OTA install helpers
 	$(hide) $(call package_files-copy-root, \
 	    $(TARGET_OUT)/install,$(zip_root)/INSTALL)


### PR DESCRIPTION
This is useful on A/B devices, offering the option to include TWRP without having to build it.

TARGET_PREBUILT_RECOVERY_RAMDISK_IMG must point to a recovery ramdisk.img
TARGET_PREBUILT_RECOVERY_RAMDISK must point to a zip archive holding a recovery ramdisk

Change-Id: Ie29feaf7802de9f84ca0e8adf47289a885b85faa
Signed-off-by: OdSazib <odsazib@gmail.com>